### PR TITLE
Fix SQL challenge schema mismatch and empty query results

### DIFF
--- a/SQL/public/index.html
+++ b/SQL/public/index.html
@@ -127,8 +127,13 @@
         if (data.error) {
           document.getElementById('result').textContent = 'エラー: ' + data.error;
         } else {
-          const resultTable = createResultTable(data.data);
           document.getElementById('result').innerHTML = '';
+          if (!Array.isArray(data.data) || data.data.length === 0) {
+            document.getElementById('result').textContent = '結果は0件でした。';
+            return;
+          }
+
+          const resultTable = createResultTable(data.data);
           document.getElementById('result').appendChild(resultTable);
         }
       })

--- a/SQL/server.js
+++ b/SQL/server.js
@@ -9,10 +9,17 @@ const db = new sqlite3.Database(':memory:');
 
 // 簡単なデータベースとテーブルの作成
 db.serialize(() => {
-  db.run("CREATE TABLE users (id INT, name TEXT)");
-  db.run("INSERT INTO users (id, name) VALUES (1, 'Alice')");
-  db.run("INSERT INTO users (id, name) VALUES (2, 'Bob')");
-  db.run("INSERT INTO users (id, name) VALUES (3, 'Charlie')");
+  db.run(`
+    CREATE TABLE users (
+      id INTEGER PRIMARY KEY,
+      name TEXT NOT NULL,
+      email TEXT UNIQUE,
+      age INTEGER
+    )
+  `);
+  db.run("INSERT INTO users (id, name, email, age) VALUES (1, 'Alice', 'alice@example.com', 30)");
+  db.run("INSERT INTO users (id, name, email, age) VALUES (2, 'Bob', 'bob@example.com', 24)");
+  db.run("INSERT INTO users (id, name, email, age) VALUES (3, 'Charlie', 'charlie@example.com', 28)");
 });
 
 // ミドルウェア


### PR DESCRIPTION
### Motivation
- The SQL challenge UI documents a `users` table with `id`, `name`, `email`, and `age`, but the in-memory DB only provided `id` and `name`, which can cause queries referenced by the UI to fail. 
- The front-end called `createResultTable(data)` unguarded and assumed `data[0]` exists, which throws when the query returns zero rows. 

### Description
- Updated `SQL/server.js` to create `users` with `id INTEGER PRIMARY KEY, name TEXT NOT NULL, email TEXT UNIQUE, age INTEGER` and adjusted seed rows to include `email` and `age`. 
- Replaced the old two-column schema and single-column inserts with the new schema and three full rows to match the UI table structure. 
- Modified `SQL/public/index.html` to check `if (!Array.isArray(data.data) || data.data.length === 0)` and display `結果は0件でした。` instead of calling `createResultTable` on empty results. 
- These changes prevent server-side column-mismatch errors and avoid front-end exceptions on zero-row responses. 

### Testing
- Ran `node --check SQL/server.js`, which succeeded with no syntax errors. 
- Attempted to run `node SQL/server.js` but runtime execution failed because required dependencies (e.g. `express`) are not installed in this environment. 
- Attempted a syntax check on the HTML file with `node --check` but Node.js reports an unknown file extension for `.html`, so no meaningful check was performed for the front-end file in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992e65632f0832a802fda677cd37ef1)